### PR TITLE
Fix parents after rootTree

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -203,21 +203,20 @@ export default function (children) {
 				next_to_last_sibling.parent = null;
 				next_to_last.parent = next_to_last_sibling;
 
-				// Remove outgroup as 
-
-				// 2. traverse the tree from the new root and modify topology.
+				// Create the new_root_node
 				var new_root_node = { id: tree.id, children: [new_root, new_root.parent] };
 
 				// Remove new_root as child of his parent.
 				var new_root_child_index = new_root.parent.children.findIndex(function (el) {
 					return el === new_root;
 				});
-
 				if (new_root_child_index !== -1) {
 					new_root.parent.children[new_root_child_index] = new_root_node;
 				}
 				else {
 				}
+
+				// Switch parent child
 				switchParentChild(new_root.parent, new_root_node);
 				new_root.parent = new_root_node;
 				return new_root_node;

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,236 +1,241 @@
-export default function (children) {
+export default function(children) {
+  var self = {};
 
-	var self = {};
+  /* Private attributes */
+  var getChildren = children == null ? defaultChildren : children;
 
-	/* Private attributes */
-	var getChildren = (children == null) ? defaultChildren : children;
+  // PRIVATE FUNCTION
+  function defaultChildren(node) {
+    return node.children;
+  }
 
-	// PRIVATE FUNCTION
-	function defaultChildren(node) {
-		return node.children;
-	}
+  function forParent(node, callback) {
+    var parent = node.parent;
+    if (parent) {
+      callback(parent);
+    }
+  }
 
-	function forParent(node, callback) {
-		var parent = node.parent;
-		if (parent) {
-			callback(parent);
-		}
-	}
+  function forLeftChildren(node, callback) {
+    var children = getChildren(node);
+    if (children) {
+      callback(children[0]);
+    }
+  }
 
-	function forLeftChildren(node, callback) {
-		var children = getChildren(node);
-		if (children) {
-			callback(children[0]);
-		}
-	}
+  function forRightChildren(node, callback) {
+    var children = getChildren(node);
+    if (children) {
+      callback(children[children.length - 1]);
+    }
+  }
 
-	function forRightChildren(node, callback) {
-		var children = getChildren(node);
-		if (children) {
-			callback(children[children.length - 1]);
-		}
-	}
+  function forEachChildren(node, callback) {
+    var children = getChildren(node);
+    if (children) {
+      children.forEach(callback);
+    }
+  }
 
-	function forEachChildren(node, callback) {
-		var children = getChildren(node);
-		if (children) {
-			children.forEach(callback);
-		}
-	}
+  function switchParentChild(node, child) {
+    // check if child is one of the children's node.
+    if (node.children) {
+      var indexChild = node.children.findIndex(function(el) {
+        return el === child;
+      });
+      if (indexChild !== -1) {
+        // the futur parent is currently the children
+        // check if child if the node's parent
+        if (node.parent) {
+          var parent = node.parent;
+          node.parent = child;
+          var newChildren = node.children
+            .slice(0, indexChild)
+            .concat(node.children.slice(indexChild + 1));
+          newChildren.push(parent);
+          node.children = newChildren;
+          switchParentChild(parent, node);
+        }
+      } else {
+        //throw("The child is not the children of the current node");
+      }
+    } else {
+      return;
+    }
+  }
 
-	function switchParentChild(node, child) {
-		// check if child is one of the children's node.
-		if (node.children) {
-			var indexChild = node.children.findIndex(function (el) {
-				return el === child;
-			});
-			if (indexChild !== -1) { // the futur parent is currently the children
-				// check if child if the node's parent
-				if (node.parent) {
-					var parent = node.parent;
-					node.parent = child;
-					var newChildren = node.children.slice(0, indexChild).concat(
-						node.children.slice(indexChild + 1)
-					);
-					newChildren.push(parent);
-					node.children = newChildren;
-					switchParentChild(parent, node);
-				}
-			}
-			else {
-				//throw("The child is not the children of the current node");
-			}
-		}
-		else {
-			return;
-		}
-	}
+  // PUBLIC FUNCTION
+  /**
+   * Invokes the specified function for node and each descendant in post-order traversal,
+   * such that a given node is only visited after all of its descendants have already been visited.
+   */
+  self.eachAfter = function(node, callback) {
+    forEachChildren(node, function(child) {
+      self.eachAfter(child, callback);
+    });
+    callback(node);
+  };
 
-	// PUBLIC FUNCTION
-    /**
-     * Invokes the specified function for node and each descendant in post-order traversal, 
-     * such that a given node is only visited after all of its descendants have already been visited.
-     */
-	self.eachAfter = function (node, callback) {
-		forEachChildren(node, function (child) {
-			self.eachAfter(child, callback);
-		});
-		callback(node);
-	};
+  self.reduceAfter = function(node, callback, acc) {
+    forEachChildren(node, function(child) {
+      acc = self.reduceAfter(child, callback, acc);
+    });
+    return callback(acc, node);
+  };
 
-	self.reduceAfter = function (node, callback, acc) {
-		forEachChildren(node, function (child) {
-			acc = self.reduceAfter(child, callback, acc);
-		});
-		return callback(acc, node);
-	};
+  self.eachBefore = function(node, callback) {
+    callback(node);
+    forEachChildren(node, function(child) {
+      self.eachBefore(child, callback);
+    });
+  };
 
-	self.eachBefore = function (node, callback) {
-		callback(node);
-		forEachChildren(node, function (child) {
-			self.eachBefore(child, callback);
-		});
-	};
+  self.reduceBefore = function(node, callback, acc) {
+    acc = callback(acc, node);
+    forEachChildren(node, function(child) {
+      acc = self.reduceBefore(child, callback, acc);
+    });
+    return acc;
+  };
 
-	self.reduceBefore = function (node, callback, acc) {
-		acc = callback(acc, node);
-		forEachChildren(node, function (child) {
-			acc = self.reduceBefore(child, callback, acc);
-		});
-		return acc;
-	};
+  self.filter = function(node, callback) {
+    return self.reduceBefore(
+      node,
+      function(acc, node) {
+        if (callback(node)) {
+          acc.push(node);
+        }
+        return acc;
+      },
+      []
+    );
+  };
 
-	self.filter = function (node, callback) {
-		return self.reduceBefore(node, function (acc, node) {
-			if (callback(node)) {
-				acc.push(node);
-			}
-			return acc;
-		}, []);
-	};
+  self.eachAncestor = function(node, callback) {
+    callback(node);
+    forParent(node, function(parent) {
+      self.eachAncestor(parent, callback);
+    });
+  };
 
-	self.eachAncestor = function (node, callback) {
-		callback(node);
-		forParent(node, function (parent) {
-			self.eachAncestor(parent, callback);
-		});
-	};
+  self.reduceAncestor = function(node, callback, acc) {
+    acc = callback(acc, node);
+    forParent(node, function(parent) {
+      acc = self.reduceAncestor(parent, callback, acc);
+    });
+    return acc;
+  };
 
-	self.reduceAncestor = function (node, callback, acc) {
-		acc = callback(acc, node);
-		forParent(node, function (parent) {
-			acc = self.reduceAncestor(parent, callback, acc);
-		});
-		return acc;
-	};
+  self.filterAncestor = function(node, callback) {
+    return self.reduceAncestor(
+      node,
+      function(acc, parent) {
+        if (callback(parent)) {
+          acc.push(parent);
+          return acc;
+        } else {
+          return acc;
+        }
+      },
+      []
+    );
+  };
 
-	self.filterAncestor = function (node, callback) {
-		return self.reduceAncestor(node, function (acc, parent) {
-			if (callback(parent)) {
-				acc.push(parent);
-				return acc;
-			}
-			else {
-				return acc;
-			}
-		}, []);
-	};
+  // self.eachAfterLeft = function(node, callback) {
+  // 	forLeftChildren(node, function(left_child) {
+  // 	    self.eachAfterLeft(left_child, callback);
+  // 	});
+  // 	callback(node);
+  // };
 
-	// self.eachAfterLeft = function(node, callback) {
-	// 	forLeftChildren(node, function(left_child) {
-	// 	    self.eachAfterLeft(left_child, callback);
-	// 	});
-	// 	callback(node);
-	// };
+  self.reduceAfterLeft = function(node, callback, acc) {
+    forLeftChildren(node, function(left_child) {
+      acc = self.reduceAfterLeft(left_child, callback, acc);
+    });
+    return callback(acc, node);
+  };
 
-	self.reduceAfterLeft = function (node, callback, acc) {
-		forLeftChildren(node, function (left_child) {
-			acc = self.reduceAfterLeft(left_child, callback, acc);
-		});
-		return callback(acc, node);
-	};
+  self.reduceAfterRight = function(node, callback, acc) {
+    forRightChildren(node, function(right_child) {
+      acc = self.reduceAfterRight(right_child, callback, acc);
+    });
+    return callback(acc, node);
+  };
 
-	self.reduceAfterRight = function (node, callback, acc) {
-		forRightChildren(node, function (right_child) {
-			acc = self.reduceAfterRight(right_child, callback, acc);
-		});
-		return callback(acc, node);
-	};
+  /**
+   *
+   */
+  self.addParent = function(node) {
+    if (!node.parent) {
+      node.parent = null;
+    }
+    var cb = function(node) {
+      var cb_set_parent = function(child) {
+        child.parent = node;
+      };
+      forEachChildren(node, cb_set_parent);
+    };
+    self.eachAfter(node, cb);
+  };
 
-    /**
-     *
-     */
-	self.addParent = function (node) {
-		if (!node.parent) {
-			node.parent = null;
-		}
-		var cb = function (node) {
-			var cb_set_parent = function (child) {
-				child.parent = node;
-			};
-			forEachChildren(node, cb_set_parent);
-		};
-		self.eachAfter(node, cb);
-	};
+  self.rootTree = function(new_root, tree) {
+    // Add parent attribute
+    self.addParent(tree);
 
-	self.rootTree = function (new_root, tree) {
-		// Add parent attribute
-		self.addParent(tree);
+    if (new_root.parent === null) {
+      return tree;
+    } else {
+      // get the next to last node before the current root
+      var next_to_last_list = self.filterAncestor(new_root, function(node) {
+        if (node.parent) {
+          return node.parent.parent == null;
+        } else {
+          return false;
+        }
+      });
 
-		if (new_root.parent === null) {
-			return tree;
-		}
-		else {
-			// get the next to last node before the current root
-			var next_to_last_list = self.filterAncestor(new_root, function (node) {
-				if (node.parent) {
-					return node.parent.parent == null;
-				}
-				else {
-					return false;
-				}
-			});
+      if (next_to_last_list.length === 1) {
+        var next_to_last = next_to_last_list[0];
 
-			if (next_to_last_list.length === 1) {
-				var next_to_last = next_to_last_list[0];
+        // get sibling of this next_to_last node
+        var next_to_last_sibling = tree.children.find(function(elem) {
+          return next_to_last !== elem;
+        });
 
-				// get sibling of this next_to_last node
-				var next_to_last_sibling = tree.children.find(function (elem) {
-					return next_to_last !== elem;
-				});
+        // Set next_to_lastSibling has parent of next_to_last.
+        next_to_last_sibling.parent = null;
+        next_to_last.parent = next_to_last_sibling;
 
-				// Set next_to_lastSibling has parent of next_to_last.
-				next_to_last_sibling.parent = null;
-				next_to_last.parent = next_to_last_sibling;
+        // Create the new_root_node
+        var new_root_node = {
+          id: tree.id,
+          children: [new_root, new_root.parent]
+        };
 
-				// Create the new_root_node
-				var new_root_node = { id: tree.id, children: [new_root, new_root.parent] };
+        // Remove new_root as child of his parent.
+        var new_root_child_index = new_root.parent.children.findIndex(function(
+          el
+        ) {
+          return el === new_root;
+        });
+        if (new_root_child_index !== -1) {
+          new_root.parent.children[new_root_child_index] = new_root_node;
+        } else {
+        }
 
-				// Remove new_root as child of his parent.
-				var new_root_child_index = new_root.parent.children.findIndex(function (el) {
-					return el === new_root;
-				});
-				if (new_root_child_index !== -1) {
-					new_root.parent.children[new_root_child_index] = new_root_node;
-				}
-				else {
-				}
+        // Switch parent child
+        switchParentChild(new_root.parent, new_root_node);
+        new_root.parent = new_root_node;
+        return new_root_node;
+      } else {
+        throw {
+          message: "Error while getting next to last ancestor",
+          name: "ExceptionNextToLastAncestor"
+        };
+        // return tree;
+      }
+    }
+  };
 
-				// Switch parent child
-				switchParentChild(new_root.parent, new_root_node);
-				new_root.parent = new_root_node;
-				return new_root_node;
-			}
-			else {
-				throw {
-					message: "Error while getting next to last ancestor",
-					name: "ExceptionNextToLastAncestor"
-
-				};
-				// return tree;
-			}
-		}
-	};
-
-	return self;
+  return self;
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -226,6 +226,9 @@ export default function(children) {
         // Switch parent child
         switchParentChild(new_root.parent, new_root_node);
         new_root.parent = new_root_node;
+
+        // Repair parent
+        self.addParent(new_root_node);
         return new_root_node;
       } else {
         throw {

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,6 +1,6 @@
 const tape = require("tape");
 var phylotree_utils = require("../build/phylotree-utils.js");
-// var phylotree_utils = require("../");
+
 function concatArrayIds(acc, node) {
   acc.push(node.id);
   return acc;

--- a/test/utils.js
+++ b/test/utils.js
@@ -6,6 +6,10 @@ function concatArrayIds(acc, node) {
   return acc;
 }
 
+function termNode(id) {
+  return { id: id, children: [] };
+}
+
 function getBigTree() {
   const node7 = { id: 7 };
   const node2 = {

--- a/test/utils.js
+++ b/test/utils.js
@@ -311,12 +311,11 @@ tape("Test root tree", (test) => {
 
     // First test: root on node 7
     const tree_a = getBigTree();
-     const node7 = (TreeUtils.filter(tree_a, (node) => node.id === 7))[0];
+    const node7 = (TreeUtils.filter(tree_a, (node) => node.id === 7))[0];
     test.equal(node7.id, 7, "Get the node 7");
-    const new_root = TreeUtils.rootTree(node7, tree_a);
-    const array_concat_7 = TreeUtils.reduceBefore(new_root, concatArrayIds, []);
+    const new_root_7 = TreeUtils.rootTree(node7, tree_a);
+    const array_concat_7 = TreeUtils.reduceBefore(new_root_7, concatArrayIds, []);
     test.deepEqual(array_concat_7, [1, 7, 8, 6, 2, 3, 4, 5, 9, 10, 11, 12, 13], "Root on the node 7 branch");
-
 
     // Second test: root on node 2
     const tree_b = getBigTree();
@@ -324,15 +323,15 @@ tape("Test root tree", (test) => {
     test.equal(node2.id, 2, "Get the node 2");
     const new_root_2 = TreeUtils.rootTree(node2, tree_b);
     const array_concat_2 = TreeUtils.reduceBefore(new_root_2, concatArrayIds, []);
-    test.deepEqual(array_concat_2, [1, 2, 3, 4, 5, 8, 6, 7, 9, 10, 11, 12, 13], "Root on node 2 OK");
+    test.deepEqual(array_concat_2, [1, 2, 3, 4, 5, 8, 6, 7, 9, 10, 11, 12, 13], "Root on node 2 branch");
 
-    // Third test: root on node 1
+    // Third test: root on node 1 (i.e. no change)
     const tree_c = getBigTree();
     const node1 = (TreeUtils.filter(tree_c, (node) => node.id === 1))[0];
     test.equal(node1.id, 1, "Get the node 1");
     const new_root_1 = TreeUtils.rootTree(node1, tree_c);
     const array_concat_1 = TreeUtils.reduceBefore(new_root_1, concatArrayIds, []);
-    test.deepEqual(array_concat_2, [1, 2, 3, 4, 5, 8, 6, 7, 9, 10, 11, 12, 13], "Tree get the right topology");
+    test.deepEqual(array_concat_1, TreeUtils.reduceBefore(getBigTree(), concatArrayIds, []), "Root on node 1 branch");
 
     test.end();
 });

--- a/test/utils.js
+++ b/test/utils.js
@@ -296,10 +296,10 @@ tape("Test Filter ancestor", (test) => {
 
 
 tape("Test root tree", (test) => {
+    const TreeUtils = phylotree_utils.utils();
 
     // First test: root on node 7
     const tree_a = getBigTree();
-    const TreeUtils = phylotree_utils.utils();
     const array_concat = TreeUtils.reduceBefore(tree_a, concatArrayIds, []);
     test.deepEqual(array_concat, [1, 2, 3, 4, 5, 8, 6, 7, 9, 10, 11, 12, 13], "Tree get the right topology");
 

--- a/test/utils.js
+++ b/test/utils.js
@@ -310,28 +310,34 @@ tape("Test root tree", (test) => {
     const TreeUtils = phylotree_utils.utils();
 
     // First test: root on node 7
-    const tree_a = getBigTree();
-    const node7 = (TreeUtils.filter(tree_a, (node) => node.id === 7))[0];
-    test.equal(node7.id, 7, "Get the node 7");
-    const new_root_7 = TreeUtils.rootTree(node7, tree_a);
-    const array_concat_7 = TreeUtils.reduceBefore(new_root_7, concatArrayIds, []);
-    test.deepEqual(array_concat_7, [1, 7, 8, 6, 2, 3, 4, 5, 9, 10, 11, 12, 13], "Root on the node 7 branch");
+    {
+        const tree_a = getBigTree();
+        const node7 = (TreeUtils.filter(tree_a, (node) => node.id === 7))[0];
+        test.equal(node7.id, 7, "Get the node 7");
+        const new_root_7 = TreeUtils.rootTree(node7, tree_a);
+        const array_concat_7 = TreeUtils.reduceBefore(new_root_7, concatArrayIds, []);
+        test.deepEqual(array_concat_7, [1, 7, 8, 6, 2, 3, 4, 5, 9, 10, 11, 12, 13], "Root on the node 7 branch");
+    }
 
     // Second test: root on node 2
-    const tree_b = getBigTree();
-    const node2 = (TreeUtils.filter(tree_b, (node) => node.id === 2))[0];
-    test.equal(node2.id, 2, "Get the node 2");
-    const new_root_2 = TreeUtils.rootTree(node2, tree_b);
-    const array_concat_2 = TreeUtils.reduceBefore(new_root_2, concatArrayIds, []);
-    test.deepEqual(array_concat_2, [1, 2, 3, 4, 5, 8, 6, 7, 9, 10, 11, 12, 13], "Root on node 2 branch");
+    {
+        const tree_b = getBigTree();
+        const node2 = (TreeUtils.filter(tree_b, (node) => node.id === 2))[0];
+        test.equal(node2.id, 2, "Get the node 2");
+        const new_root_2 = TreeUtils.rootTree(node2, tree_b);
+        const array_concat_2 = TreeUtils.reduceBefore(new_root_2, concatArrayIds, []);
+        test.deepEqual(array_concat_2, [1, 2, 3, 4, 5, 8, 6, 7, 9, 10, 11, 12, 13], "Root on node 2 branch");
+    }
 
     // Third test: root on node 1 (i.e. no change)
-    const tree_c = getBigTree();
-    const node1 = (TreeUtils.filter(tree_c, (node) => node.id === 1))[0];
-    test.equal(node1.id, 1, "Get the node 1");
-    const new_root_1 = TreeUtils.rootTree(node1, tree_c);
-    const array_concat_1 = TreeUtils.reduceBefore(new_root_1, concatArrayIds, []);
-    test.deepEqual(array_concat_1, TreeUtils.reduceBefore(getBigTree(), concatArrayIds, []), "Root on node 1 branch");
+    {
+        const tree_c = getBigTree();
+        const node1 = (TreeUtils.filter(tree_c, (node) => node.id === 1))[0];
+        test.equal(node1.id, 1, "Get the node 1");
+        const new_root_1 = TreeUtils.rootTree(node1, tree_c);
+        const array_concat_1 = TreeUtils.reduceBefore(new_root_1, concatArrayIds, []);
+        test.deepEqual(array_concat_1, TreeUtils.reduceBefore(getBigTree(), concatArrayIds, []), "Root on node 1 branch");
+    }
 
     test.end();
 });

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,451 +1,488 @@
 var tape = require("tape");
 var phylotree_utils = require("../");
 function concatArrayIds(acc, node) {
-    acc.push(node.id);
-    return acc;
-};
-
+  acc.push(node.id);
+  return acc;
+}
 
 function termNode(id) {
-    return { id: id, children: [] }
+  return { id: id, children: [] };
 }
-
 
 function getBigTree() {
-    const node7 = { id: 7 };
-    const node2 = {
-        id: 2,
+  const node7 = { id: 7 };
+  const node2 = {
+    id: 2,
+    children: [
+      {
+        id: 3,
         children: [
-            {
-                id: 3,
-                children: [
-                    {
-                        id: 4
-                    },
-                    {
-                        id: 5
-                    }
-                ]
-            },
-            {
-                id: 8,
-                children: [
-                    {
-                        id: 6
-                    },
-                    node7
-                ]
-            }
+          {
+            id: 4
+          },
+          {
+            id: 5
+          }
         ]
-    };
-    const node13 = { id: 13 };
-    return {
-        id: 1,
+      },
+      {
+        id: 8,
         children: [
-            node2,
-            {
-                id: 9,
-                children: [
-                    {
-                        id: 10,
-                        children: [
-                            {
-                                id: 11
-                            },
-                            {
-                                id: 12
-                            }
-                        ]
-                    },
-                    node13
-                ]
-            }
+          {
+            id: 6
+          },
+          node7
         ]
-    };
+      }
+    ]
+  };
+  const node13 = { id: 13 };
+  return {
+    id: 1,
+    children: [
+      node2,
+      {
+        id: 9,
+        children: [
+          {
+            id: 10,
+            children: [
+              {
+                id: 11
+              },
+              {
+                id: 12
+              }
+            ]
+          },
+          node13
+        ]
+      }
+    ]
+  };
 }
-
 
 function getTestTree1() {
-    return {
+  return {
+    children: [
+      {
         children: [
-            {
-                children: [
-                    {
-                        children: [
-                            termNode("Roseo1"),
-                            termNode("Roseo2")
-                        ]
-                    },
-                    termNode("Rhizo")
-                ]
-            },
-            termNode("outgroup")
+          {
+            children: [termNode("Roseo1"), termNode("Roseo2")]
+          },
+          termNode("Rhizo")
         ]
-    }
+      },
+      termNode("outgroup")
+    ]
+  };
 }
-
 
 function getTestTree2() {
-    return {
+  return {
+    children: [
+      {
+        children: [termNode("Roseo1"), termNode("Roseo2")]
+      },
+      {
         children: [
-            {
-                children: [
-                    termNode("Roseo1"),
-                    termNode("Roseo2")
-                ]
-            },
-            {
-                children: [
-                    {
-                        children: [
-                            termNode("Rhizo"),
-                            termNode("Pseudo")
-                        ]
-                    },
-                    termNode("outgroup")
-                ]
-            }
+          {
+            children: [termNode("Rhizo"), termNode("Pseudo")]
+          },
+          termNode("outgroup")
         ]
-    }
+      }
+    ]
+  };
 }
 
+tape("Tree post order traversal (eachAfter)", function(test) {
+  var tree = {
+    id: 1,
+    children: [{ id: 2, children: [{ id: 4 }, { id: 5 }] }, { id: 3 }]
+  };
+  var node_ids_traversal = [];
+  phylotree_utils.utils().eachAfter(tree, function(node) {
+    node_ids_traversal.push(node.id);
+  });
+  var traversal_signature = node_ids_traversal.join(";");
+  test.equal(traversal_signature, "4;5;2;3;1");
 
-tape("Tree post order traversal (eachAfter)", function (test) {
-    var tree = { id: 1, children: [{ id: 2, children: [{ id: 4 }, { id: 5 }] }, { id: 3 }] };
-    var node_ids_traversal = [];
-    phylotree_utils
-        .utils()
-        .eachAfter(tree, function (node) {
-            node_ids_traversal.push(node.id);
-        });
-    var traversal_signature = node_ids_traversal.join(";");
-    test.equal(traversal_signature, "4;5;2;3;1");
-
-    test.end();
+  test.end();
 });
 
+tape("Tree pre order traversal (eachBefore)", function(test) {
+  var tree = {
+    id: 1,
+    children: [{ id: 2, children: [{ id: 4 }, { id: 5 }] }, { id: 3 }]
+  };
+  var node_ids_traversal = [];
+  phylotree_utils.utils().eachBefore(tree, function(node) {
+    node_ids_traversal.push(node.id);
+  });
+  var traversal_signature = node_ids_traversal.join(";");
+  test.equal(traversal_signature, "1;2;4;5;3");
 
-tape("Tree pre order traversal (eachBefore)", function (test) {
-    var tree = { id: 1, children: [{ id: 2, children: [{ id: 4 }, { id: 5 }] }, { id: 3 }] };
-    var node_ids_traversal = [];
-    phylotree_utils
-        .utils()
-        .eachBefore(tree, function (node) {
-            node_ids_traversal.push(node.id);
-        });
-    var traversal_signature = node_ids_traversal.join(";");
-    test.equal(traversal_signature, "1;2;4;5;3");
-
-    test.end();
+  test.end();
 });
 
-
-tape("Children accessor", function (test) {
-    var tree = {
-        id: 1,
+tape("Children accessor", function(test) {
+  var tree = {
+    id: 1,
+    childs: [
+      {
+        id: 2,
         childs: [
-            {
-                id: 2,
-                childs: [
-                    {
-                        id: 4
-                    },
-                    {
-                        id: 5
-                    }
-                ]
-            },
-            {
-                id: 3
-            }
+          {
+            id: 4
+          },
+          {
+            id: 5
+          }
         ]
-    };
-    var childAcc = function (node) {
-        return node.childs;
-    };
+      },
+      {
+        id: 3
+      }
+    ]
+  };
+  var childAcc = function(node) {
+    return node.childs;
+  };
 
-    var node_ids_traversal = [];
-    phylotree_utils
-        .utils(childAcc)
-        .eachAfter(tree, function (node) {
-            node_ids_traversal.push(node.id);
-        });
-    var traversal_signature = node_ids_traversal.join(";");
-    test.equal(traversal_signature, "4;5;2;3;1");
+  var node_ids_traversal = [];
+  phylotree_utils.utils(childAcc).eachAfter(tree, function(node) {
+    node_ids_traversal.push(node.id);
+  });
+  var traversal_signature = node_ids_traversal.join(";");
+  test.equal(traversal_signature, "4;5;2;3;1");
 
-    test.end();
+  test.end();
 });
 
+tape("Test addParent function", function(test) {
+  var tree = {
+    id: 1,
+    children: [{ id: 2, children: [{ id: 4 }, { id: 5 }] }, { id: 3 }]
+  };
+  var node_ids_traversal = [];
+  const TreeUtils = phylotree_utils.utils();
+  TreeUtils.addParent(tree);
+  TreeUtils.eachAfter(tree, function(node) {
+    if (node.parent) {
+      node_ids_traversal.push(node.id + "_" + node.parent.id);
+    } else {
+      node_ids_traversal.push(node.id + "_null");
+    }
+  });
+  var traversal_signature = node_ids_traversal.join(";");
+  test.equal(traversal_signature, "4_2;5_2;2_1;3_1;1_null");
 
-tape("Test addParent function", function (test) {
-    var tree = { id: 1, children: [{ id: 2, children: [{ id: 4 }, { id: 5 }] }, { id: 3 }] };
-    var node_ids_traversal = [];
-    const TreeUtils = phylotree_utils.utils();
-    TreeUtils.addParent(tree);
-    TreeUtils.eachAfter(tree, function (node) {
-        if (node.parent) {
-            node_ids_traversal.push(node.id + "_" + node.parent.id);
-        }
-        else {
-            node_ids_traversal.push(node.id + "_null");
-        }
+  test.end();
+});
+
+tape("Test reduceAfter", function(test) {
+  var tree = {
+    id: 1,
+    children: [{ id: 2, children: [{ id: 4 }, { id: 5 }] }, { id: 3 }]
+  };
+  const TreeUtils = phylotree_utils.utils();
+
+  var sumAccCb = function(acc, curr) {
+    return acc + curr.id;
+  };
+  var sum = TreeUtils.reduceAfter(tree, sumAccCb, 0);
+  test.equal(sum, 15);
+
+  var concat = TreeUtils.reduceAfter(tree, sumAccCb, "");
+  test.equal(concat, "45231");
+
+  var array_concat = [];
+  array_concat = TreeUtils.reduceAfter(tree, concatArrayIds, array_concat);
+  test.deepEqual(array_concat, [4, 5, 2, 3, 1], array_concat);
+
+  test.end();
+});
+
+tape("Test reduceBefore", function(test) {
+  var tree = {
+    id: 1,
+    children: [{ id: 2, children: [{ id: 4 }, { id: 5 }] }, { id: 3 }]
+  };
+  const TreeUtils = phylotree_utils.utils();
+
+  var sumAccCb = function(acc, curr) {
+    return acc + curr.id;
+  };
+  var sum = TreeUtils.reduceBefore(tree, sumAccCb, 0);
+  test.equal(sum, 15);
+
+  var concat = TreeUtils.reduceBefore(tree, sumAccCb, "");
+  test.equal(concat, "12453");
+
+  var array_concat = [];
+  array_concat = TreeUtils.reduceBefore(tree, concatArrayIds, array_concat);
+  test.deepEqual(array_concat, [1, 2, 4, 5, 3]);
+
+  test.end();
+});
+
+tape("Test filter nodes", test => {
+  var tree = {
+    id: 1,
+    children: [{ id: 2, children: [{ id: 4 }, { id: 5 }] }, { id: 3 }]
+  };
+  const TreeUtils = phylotree_utils.utils();
+
+  var res = TreeUtils.filter(tree, node => {
+    return node.id < 3;
+  }).map(node => {
+    return node.id;
+  });
+  test.deepEqual(res, [1, 2]);
+
+  var res2 = TreeUtils.filter(tree, node => {
+    return node.id >= 3;
+  }).map(node => {
+    return node.id;
+  });
+  test.deepEqual(res2, [4, 5, 3]);
+
+  test.end();
+});
+
+tape("Test each ancestor", test => {
+  const node5 = { id: 5 };
+  const node3 = { id: 3 };
+  var tree = {
+    id: 1,
+    children: [{ id: 2, children: [{ id: 4 }, node5] }, node3]
+  };
+  const TreeUtils = phylotree_utils.utils();
+  TreeUtils.addParent(tree);
+  var ancestor_record = [];
+  TreeUtils.eachAncestor(node5, node => {
+    ancestor_record.push(node.id);
+  });
+
+  test.deepEqual(ancestor_record, [5, 2, 1]);
+
+  ancestor_record = [];
+  TreeUtils.eachAncestor(node3, node => {
+    ancestor_record.push(node.id);
+  });
+  test.deepEqual(ancestor_record, [3, 1]);
+
+  test.end();
+});
+
+tape("Test reduce ancestor", test => {
+  const node5 = { id: 5 };
+  const node3 = { id: 3 };
+  var tree = {
+    id: 1,
+    children: [{ id: 2, children: [{ id: 4 }, node5] }, node3]
+  };
+  const TreeUtils = phylotree_utils.utils();
+  TreeUtils.addParent(tree);
+
+  const res = TreeUtils.reduceAncestor(
+    node5,
+    (acc, node) => {
+      acc.push(node.id);
+      return acc;
+    },
+    []
+  );
+
+  test.deepEqual(res, [5, 2, 1]);
+
+  test.end();
+});
+
+tape("Test Filter ancestor", test => {
+  const node5 = { id: 5 };
+  const node3 = { id: 3 };
+  var tree = {
+    id: 1,
+    children: [{ id: 2, children: [{ id: 4 }, node5] }, node3]
+  };
+  const TreeUtils = phylotree_utils.utils();
+  TreeUtils.addParent(tree);
+  const res = TreeUtils.filterAncestor(node5, node => {
+    return node.id === 1;
+  }).map(node => {
+    return node.id;
+  });
+
+  test.deepEqual(res, [1]);
+
+  // Get nextToLast
+  const res2 = TreeUtils.filterAncestor(node5, parent => {
+    if (parent.parent) {
+      return parent.parent.parent == null;
+    } else {
+      return false;
+    }
+  }).map(node => {
+    return node.id;
+  });
+  test.deepEqual(res2, [2]);
+
+  const res3 = TreeUtils.filterAncestor(node3, parent => {
+    if (parent.parent) {
+      return parent.parent.parent == null;
+    } else {
+      return false;
+    }
+  }).map(node => {
+    return node.id;
+  });
+  test.deepEqual(res3, [3]);
+
+  test.end();
+});
+
+tape("Test getBigTree", test => {
+  const TreeUtils = phylotree_utils.utils();
+
+  const tree_a = getBigTree();
+  const array_concat = TreeUtils.reduceBefore(tree_a, concatArrayIds, []);
+  test.deepEqual(
+    array_concat,
+    [1, 2, 3, 4, 5, 8, 6, 7, 9, 10, 11, 12, 13],
+    "Tree get the right topology"
+  );
+
+  test.end();
+});
+
+tape("Test root tree", test => {
+  const TreeUtils = phylotree_utils.utils();
+
+  // First test: root on node 7
+  {
+    const tree_a = getBigTree();
+    const node7 = TreeUtils.filter(tree_a, node => node.id === 7)[0];
+    test.equal(node7.id, 7, "Get the node 7");
+    const new_root_7 = TreeUtils.rootTree(node7, tree_a);
+    const array_concat_7 = TreeUtils.reduceBefore(
+      new_root_7,
+      concatArrayIds,
+      []
+    );
+    test.deepEqual(
+      array_concat_7,
+      [1, 7, 8, 6, 2, 3, 4, 5, 9, 10, 11, 12, 13],
+      "Root on the node 7 branch"
+    );
+  }
+
+  // Second test: root on node 2
+  {
+    const tree_b = getBigTree();
+    const node2 = TreeUtils.filter(tree_b, node => node.id === 2)[0];
+    test.equal(node2.id, 2, "Get the node 2");
+    const new_root_2 = TreeUtils.rootTree(node2, tree_b);
+    const array_concat_2 = TreeUtils.reduceBefore(
+      new_root_2,
+      concatArrayIds,
+      []
+    );
+    test.deepEqual(
+      array_concat_2,
+      [1, 2, 3, 4, 5, 8, 6, 7, 9, 10, 11, 12, 13],
+      "Root on node 2 branch"
+    );
+  }
+
+  // Third test: root on node 1 (i.e. no change)
+  {
+    const tree_c = getBigTree();
+    const node1 = TreeUtils.filter(tree_c, node => node.id === 1)[0];
+    test.equal(node1.id, 1, "Get the node 1");
+    const new_root_1 = TreeUtils.rootTree(node1, tree_c);
+    const array_concat_1 = TreeUtils.reduceBefore(
+      new_root_1,
+      concatArrayIds,
+      []
+    );
+    test.deepEqual(
+      array_concat_1,
+      TreeUtils.reduceBefore(getBigTree(), concatArrayIds, []),
+      "Root on node 1 branch"
+    );
+  }
+
+  // Fourth test
+  {
+    const tree = getTestTree1();
+    const outgroup = TreeUtils.filter(tree, node => node.id === "outgroup")[0];
+    test.equal(outgroup.id, "outgroup", "Get the outgroup");
+    const new_root = TreeUtils.rootTree(outgroup, tree);
+    const empty_parent = TreeUtils.filter(new_root, node => {
+      if (node.parent) {
+        return node.parent == null;
+      } else {
+        return true;
+      }
     });
-    var traversal_signature = node_ids_traversal.join(";");
-    test.equal(traversal_signature, "4_2;5_2;2_1;3_1;1_null");
+    test.equal(empty_parent.length, 1, "No non-parent node inside tree");
+  }
 
-    test.end();
-});
-
-
-tape("Test reduceAfter", function (test) {
-    var tree = { id: 1, children: [{ id: 2, children: [{ id: 4 }, { id: 5 }] }, { id: 3 }] };
-    const TreeUtils = phylotree_utils.utils();
-
-    var sumAccCb = function (acc, curr) {
-        return acc + curr.id;
-    };
-    var sum = TreeUtils.reduceAfter(tree, sumAccCb, 0);
-    test.equal(sum, 15);
-
-    var concat = TreeUtils.reduceAfter(tree, sumAccCb, "");
-    test.equal(concat, "45231");
-
-    var array_concat = [];
-    array_concat = TreeUtils.reduceAfter(tree, concatArrayIds, array_concat);
-    test.deepEqual(array_concat, [4, 5, 2, 3, 1], array_concat);
-
-    test.end();
-});
-
-
-tape("Test reduceBefore", function (test) {
-    var tree = { id: 1, children: [{ id: 2, children: [{ id: 4 }, { id: 5 }] }, { id: 3 }] };
-    const TreeUtils = phylotree_utils.utils();
-
-    var sumAccCb = function (acc, curr) {
-        return acc + curr.id;
-    };
-    var sum = TreeUtils.reduceBefore(tree, sumAccCb, 0);
-    test.equal(sum, 15);
-
-    var concat = TreeUtils.reduceBefore(tree, sumAccCb, "");
-    test.equal(concat, "12453");
-
-    var array_concat = [];
-    array_concat = TreeUtils.reduceBefore(tree, concatArrayIds, array_concat);
-    test.deepEqual(array_concat, [1, 2, 4, 5, 3]);
-
-    test.end();
-});
-
-
-tape("Test filter nodes", (test) => {
-    var tree = { id: 1, children: [{ id: 2, children: [{ id: 4 }, { id: 5 }] }, { id: 3 }] };
-    const TreeUtils = phylotree_utils.utils();
-
-    var res = TreeUtils.filter(tree, (node) => {
-        return node.id < 3;
-    }).map((node) => {
-        return node.id;
+  // Fifth test
+  {
+    const tree = getTestTree2();
+    const outgroup = TreeUtils.filter(tree, node => node.id === "outgroup")[0];
+    test.equal(outgroup.id, "outgroup", "Get the outgroup");
+    const new_root = TreeUtils.rootTree(outgroup, tree);
+    const empty_parent = TreeUtils.filter(new_root, node => {
+      if (node.parent) {
+        return node.parent == null;
+      } else {
+        return true;
+      }
     });
-    test.deepEqual(res, [1, 2]);
+    test.equal(empty_parent.length, 1, "No non-parent node inside tree");
+  }
 
-    var res2 = TreeUtils.filter(tree, (node) => {
-        return node.id >= 3;
-    }).map((node) => {
-        return node.id;
-    });
-    test.deepEqual(res2, [4, 5, 3]);
-
-    test.end();
+  test.end();
 });
 
-
-tape("Test each ancestor", (test) => {
-    const node5 = { id: 5 };
-    const node3 = { id: 3 };
-    var tree = { id: 1, children: [{ id: 2, children: [{ id: 4 }, node5] }, node3] };
-    const TreeUtils = phylotree_utils.utils();
-    TreeUtils.addParent(tree);
-    var ancestor_record = [];
-    TreeUtils.eachAncestor(node5, (node) => {
-        ancestor_record.push(node.id);
-    });
-
-    test.deepEqual(ancestor_record, [5, 2, 1]);
-
-    ancestor_record = [];
-    TreeUtils.eachAncestor(node3, (node) => {
-        ancestor_record.push(node.id);
-    });
-    test.deepEqual(ancestor_record, [3, 1]);
-
-    test.end();
-});
-
-
-tape("Test reduce ancestor", (test) => {
-    const node5 = { id: 5 };
-    const node3 = { id: 3 };
-    var tree = { id: 1, children: [{ id: 2, children: [{ id: 4 }, node5] }, node3] };
-    const TreeUtils = phylotree_utils.utils();
-    TreeUtils.addParent(tree);
-
-    const res = TreeUtils.reduceAncestor(node5, (acc, node) => {
-        acc.push(node.id);
+tape("Test reduceAfterLeft", test => {
+  const tree_a = getBigTree();
+  const TreeUtils = phylotree_utils.utils();
+  const left_node = TreeUtils.reduceAfterLeft(
+    tree_a,
+    function(acc, left) {
+      if (!left.children) {
+        return left;
+      } else {
         return acc;
-    }, []);
+      }
+    },
+    null
+  );
+  test.deepEqual(left_node.id, 4, "Get the left node");
 
-    test.deepEqual(res, [5, 2, 1]);
-
-    test.end();
+  test.end();
 });
 
+tape("Test reduceAfterRight", test => {
+  const tree_a = getBigTree();
+  const TreeUtils = phylotree_utils.utils();
+  const node = TreeUtils.reduceAfterRight(
+    tree_a,
+    function(acc, child) {
+      if (!child.children) {
+        return child;
+      } else {
+        return acc;
+      }
+    },
+    null
+  );
+  test.deepEqual(node.id, 13, "Get the left node");
 
-tape("Test Filter ancestor", (test) => {
-    const node5 = { id: 5 };
-    const node3 = { id: 3 };
-    var tree = { id: 1, children: [{ id: 2, children: [{ id: 4 }, node5] }, node3] };
-    const TreeUtils = phylotree_utils.utils();
-    TreeUtils.addParent(tree);
-    const res = TreeUtils.filterAncestor(node5, (node) => {
-        return node.id === 1;
-    }).map((node) => {
-        return node.id;
-    });
-
-    test.deepEqual(res, [1]);
-
-    // Get nextToLast
-    const res2 = TreeUtils.filterAncestor(node5, (parent) => {
-        if (parent.parent) {
-            return parent.parent.parent == null;
-        }
-        else {
-            return false;
-        }
-    }).map((node) => {
-        return node.id;
-    });
-    test.deepEqual(res2, [2]);
-
-    const res3 = TreeUtils.filterAncestor(node3, (parent) => {
-        if (parent.parent) {
-            return parent.parent.parent == null;
-        }
-        else {
-            return false;
-        }
-    }).map((node) => {
-        return node.id;
-    });
-    test.deepEqual(res3, [3]);
-
-    test.end();
-});
-
-
-tape("Test getBigTree", (test) => {
-    const TreeUtils = phylotree_utils.utils();
-
-    const tree_a = getBigTree();
-    const array_concat = TreeUtils.reduceBefore(tree_a, concatArrayIds, []);
-    test.deepEqual(array_concat, [1, 2, 3, 4, 5, 8, 6, 7, 9, 10, 11, 12, 13], "Tree get the right topology");
-
-    test.end();
-});
-
-
-tape("Test root tree", (test) => {
-    const TreeUtils = phylotree_utils.utils();
-
-    // First test: root on node 7
-    {
-        const tree_a = getBigTree();
-        const node7 = (TreeUtils.filter(tree_a, (node) => node.id === 7))[0];
-        test.equal(node7.id, 7, "Get the node 7");
-        const new_root_7 = TreeUtils.rootTree(node7, tree_a);
-        const array_concat_7 = TreeUtils.reduceBefore(new_root_7, concatArrayIds, []);
-        test.deepEqual(array_concat_7, [1, 7, 8, 6, 2, 3, 4, 5, 9, 10, 11, 12, 13], "Root on the node 7 branch");
-    }
-
-    // Second test: root on node 2
-    {
-        const tree_b = getBigTree();
-        const node2 = (TreeUtils.filter(tree_b, (node) => node.id === 2))[0];
-        test.equal(node2.id, 2, "Get the node 2");
-        const new_root_2 = TreeUtils.rootTree(node2, tree_b);
-        const array_concat_2 = TreeUtils.reduceBefore(new_root_2, concatArrayIds, []);
-        test.deepEqual(array_concat_2, [1, 2, 3, 4, 5, 8, 6, 7, 9, 10, 11, 12, 13], "Root on node 2 branch");
-    }
-
-    // Third test: root on node 1 (i.e. no change)
-    {
-        const tree_c = getBigTree();
-        const node1 = (TreeUtils.filter(tree_c, (node) => node.id === 1))[0];
-        test.equal(node1.id, 1, "Get the node 1");
-        const new_root_1 = TreeUtils.rootTree(node1, tree_c);
-        const array_concat_1 = TreeUtils.reduceBefore(new_root_1, concatArrayIds, []);
-        test.deepEqual(array_concat_1, TreeUtils.reduceBefore(getBigTree(), concatArrayIds, []), "Root on node 1 branch");
-    }
-
-    // Fourth test
-    {
-        const tree = getTestTree1();
-        const outgroup = (TreeUtils.filter(tree, (node) => node.id === "outgroup"))[0];
-        test.equal(outgroup.id, "outgroup", "Get the outgroup");
-        const new_root = TreeUtils.rootTree(outgroup, tree);
-        const empty_parent = TreeUtils.filter(new_root, (node) => {
-            if (node.parent) { return node.parent == null } else { return true };
-        });
-        test.equal(empty_parent.length, 1, "No non-parent node inside tree");
-    }
-
-    // Fifth test
-    {
-        const tree = getTestTree2();
-        const outgroup = (TreeUtils.filter(tree, (node) => node.id === "outgroup"))[0];
-        test.equal(outgroup.id, "outgroup", "Get the outgroup");
-        const new_root = TreeUtils.rootTree(outgroup, tree);
-        const empty_parent = TreeUtils.filter(new_root, (node) => {
-            if (node.parent) { return node.parent == null } else { return true };
-        });
-        test.equal(empty_parent.length, 1, "No non-parent node inside tree");
-    }
-
-    test.end();
-});
-
-
-tape("Test reduceAfterLeft", (test) => {
-    const tree_a = getBigTree();
-    const TreeUtils = phylotree_utils.utils();
-    const left_node = TreeUtils.reduceAfterLeft(tree_a, function (acc, left) {
-        if (!left.children) {
-            return left;
-        }
-        else {
-            return acc;
-        }
-    }, null);
-    test.deepEqual(left_node.id, 4, "Get the left node");
-
-    test.end();
-});
-
-
-tape("Test reduceAfterRight", (test) => {
-    const tree_a = getBigTree();
-    const TreeUtils = phylotree_utils.utils();
-    const node = TreeUtils.reduceAfterRight(tree_a, function (acc, child) {
-        if (!child.children) {
-            return child;
-        }
-        else {
-            return acc;
-        }
-    }, null);
-    test.deepEqual(node.id, 13, "Get the left node");
-
-    test.end();
+  test.end();
 });

--- a/test/utils.js
+++ b/test/utils.js
@@ -6,6 +6,11 @@ function concatArrayIds(acc, node) {
 };
 
 
+function termNode(id) {
+    return { id: id, children: [] }
+}
+
+
 function getBigTree() {
     const node7 = { id: 7 };
     const node2 = {
@@ -57,6 +62,51 @@ function getBigTree() {
             }
         ]
     };
+}
+
+
+function getTestTree1() {
+    return {
+        children: [
+            {
+                children: [
+                    {
+                        children: [
+                            termNode("Roseo1"),
+                            termNode("Roseo2")
+                        ]
+                    },
+                    termNode("Rhizo")
+                ]
+            },
+            termNode("outgroup")
+        ]
+    }
+}
+
+
+function getTestTree2() {
+    return {
+        children: [
+            {
+                children: [
+                    termNode("Roseo1"),
+                    termNode("Roseo2")
+                ]
+            },
+            {
+                children: [
+                    {
+                        children: [
+                            termNode("Rhizo"),
+                            termNode("Pseudo")
+                        ]
+                    },
+                    termNode("outgroup")
+                ]
+            }
+        ]
+    }
 }
 
 
@@ -337,6 +387,30 @@ tape("Test root tree", (test) => {
         const new_root_1 = TreeUtils.rootTree(node1, tree_c);
         const array_concat_1 = TreeUtils.reduceBefore(new_root_1, concatArrayIds, []);
         test.deepEqual(array_concat_1, TreeUtils.reduceBefore(getBigTree(), concatArrayIds, []), "Root on node 1 branch");
+    }
+
+    // Fourth test
+    {
+        const tree = getTestTree1();
+        const outgroup = (TreeUtils.filter(tree, (node) => node.id === "outgroup"))[0];
+        test.equal(outgroup.id, "outgroup", "Get the outgroup");
+        const new_root = TreeUtils.rootTree(outgroup, tree);
+        const empty_parent = TreeUtils.filter(new_root, (node) => {
+            if (node.parent) { return node.parent == null } else { return true };
+        });
+        test.equal(empty_parent.length, 1, "No non-parent node inside tree");
+    }
+
+    // Fifth test
+    {
+        const tree = getTestTree2();
+        const outgroup = (TreeUtils.filter(tree, (node) => node.id === "outgroup"))[0];
+        test.equal(outgroup.id, "outgroup", "Get the outgroup");
+        const new_root = TreeUtils.rootTree(outgroup, tree);
+        const empty_parent = TreeUtils.filter(new_root, (node) => {
+            if (node.parent) { return node.parent == null } else { return true };
+        });
+        test.equal(empty_parent.length, 1, "No non-parent node inside tree");
     }
 
     test.end();

--- a/test/utils.js
+++ b/test/utils.js
@@ -295,15 +295,23 @@ tape("Test Filter ancestor", (test) => {
 });
 
 
+tape("Test getBigTree", (test) => {
+    const TreeUtils = phylotree_utils.utils();
+
+    const tree_a = getBigTree();
+    const array_concat = TreeUtils.reduceBefore(tree_a, concatArrayIds, []);
+    test.deepEqual(array_concat, [1, 2, 3, 4, 5, 8, 6, 7, 9, 10, 11, 12, 13], "Tree get the right topology");
+
+    test.end();
+});
+
+
 tape("Test root tree", (test) => {
     const TreeUtils = phylotree_utils.utils();
 
     // First test: root on node 7
     const tree_a = getBigTree();
-    const array_concat = TreeUtils.reduceBefore(tree_a, concatArrayIds, []);
-    test.deepEqual(array_concat, [1, 2, 3, 4, 5, 8, 6, 7, 9, 10, 11, 12, 13], "Tree get the right topology");
-
-    const node7 = (TreeUtils.filter(tree_a, (node) => node.id === 7))[0];
+     const node7 = (TreeUtils.filter(tree_a, (node) => node.id === 7))[0];
     test.equal(node7.id, 7, "Get the node 7");
     const new_root = TreeUtils.rootTree(node7, tree_a);
     const array_concat_7 = TreeUtils.reduceBefore(new_root, concatArrayIds, []);
@@ -314,7 +322,6 @@ tape("Test root tree", (test) => {
     const tree_b = getBigTree();
     const node2 = (TreeUtils.filter(tree_b, (node) => node.id === 2))[0];
     test.equal(node2.id, 2, "Get the node 2");
-    test.deepEqual(array_concat, [1, 2, 3, 4, 5, 8, 6, 7, 9, 10, 11, 12, 13], "Tree get the right topology");
     const new_root_2 = TreeUtils.rootTree(node2, tree_b);
     const array_concat_2 = TreeUtils.reduceBefore(new_root_2, concatArrayIds, []);
     test.deepEqual(array_concat_2, [1, 2, 3, 4, 5, 8, 6, 7, 9, 10, 11, 12, 13], "Root on node 2 OK");
@@ -323,7 +330,6 @@ tape("Test root tree", (test) => {
     const tree_c = getBigTree();
     const node1 = (TreeUtils.filter(tree_c, (node) => node.id === 1))[0];
     test.equal(node1.id, 1, "Get the node 1");
-    test.deepEqual(array_concat, [1, 2, 3, 4, 5, 8, 6, 7, 9, 10, 11, 12, 13], "Tree get the right topology");
     const new_root_1 = TreeUtils.rootTree(node1, tree_c);
     const array_concat_1 = TreeUtils.reduceBefore(new_root_1, concatArrayIds, []);
     test.deepEqual(array_concat_2, [1, 2, 3, 4, 5, 8, 6, 7, 9, 10, 11, 12, 13], "Tree get the right topology");


### PR DESCRIPTION
This PR modifies the implementation of the `rootTree` function because in some cases, several nodes have a `null` parent.

7c7ffbfb605c56382f04a0c8e19a84345df1ea55 adds tests: we count the number of nodes where is `null` after `rootTree`. The modification itself is done in fc4ae49e313d8457721019414c7635389f409def. Before that commit, the tests fail.

The modification it self is rather simple: we simple call `addParent` at the end of the function to fix the `parent` property.

The PR also make minor modification in the tests (the test of `rootTree` is more modular and we separated the test of `getBigTree`).